### PR TITLE
Add runManagedFinal

### DIFF
--- a/test/Polysemy/ManagedSpec.hs
+++ b/test/Polysemy/ManagedSpec.hs
@@ -36,7 +36,7 @@ run mv p = do
 
 spec :: Spec
 spec = describe "Polysemy.ManagedSpec" $ do
-  it "De-allocated allocated resource" $ H.requireTest $ do
+  it "De-allocated allocated resource (embed)" $ H.requireTest $ do
     mva <- liftIO IO.newEmptyMVar
     result1 <- liftIO $ runMainEffects $
       PY.runManaged $ do
@@ -47,12 +47,50 @@ spec = describe "Polysemy.ManagedSpec" $ do
 
     result1 === Nothing
     result2 === Just ()
-  it "Has local capability" $ H.requireTest $ do
+
+  it "De-allocated allocated resource (final)" $ H.requireTest $ do
+    mva <- liftIO IO.newEmptyMVar
+    result1 <- liftIO $ runMainEffects $
+      PY.runManagedFinal $ do
+        void $ MTR.allocate (return ()) $ const (IO.putMVar mva ())
+        liftIO $ IO.tryTakeMVar mva
+
+    result2 <- liftIO $ IO.tryTakeMVar mva
+
+    result1 === Nothing
+    result2 === Just ()
+
+  it "Has local capability (embed)" $ H.requireTest $ do
     mAssertions <- liftIO $ IO.newMVar []
     mva <- liftIO IO.newEmptyMVar
     mvb <- liftIO IO.newEmptyMVar
     liftIO $ runMainEffects $ do
       PY.runManaged $ do
+        void $ MTR.allocate (return ()) $ const (IO.putMVar mva ())
+        PY.managedLocal $ do
+          liftIO $ IO.tryReadMVar mva >>= \result -> run mAssertions $ result === Nothing
+          liftIO $ IO.tryReadMVar mvb >>= \result -> run mAssertions $ result === Nothing
+          void $ MTR.allocate (return ()) $ const $ IO.putMVar mvb ()
+          liftIO $ IO.tryReadMVar mva >>= \result -> run mAssertions $ result === Nothing
+          liftIO $ IO.tryReadMVar mvb >>= \result -> run mAssertions $ result === Nothing
+        liftIO $ IO.tryReadMVar mva >>= \result -> run mAssertions $ result === Nothing
+        liftIO $ IO.tryReadMVar mvb >>= \result -> run mAssertions $ result === Just ()
+      liftIO $ IO.tryReadMVar mva >>= \result -> run mAssertions $ result === Just ()
+      liftIO $ IO.tryReadMVar mvb >>= \result -> run mAssertions $ result === Just ()
+
+    liftIO $ IO.tryReadMVar mva >>= \result -> run mAssertions $ result === Just ()
+    liftIO $ IO.tryReadMVar mvb >>= \result -> run mAssertions $ result === Just ()
+
+    assertions <- fmap reverse . liftIO $ IO.readMVar mAssertions
+
+    forM_ assertions id
+
+  it "Has local capability (final)" $ H.requireTest $ do
+    mAssertions <- liftIO $ IO.newMVar []
+    mva <- liftIO IO.newEmptyMVar
+    mvb <- liftIO IO.newEmptyMVar
+    liftIO $ runMainEffects $ do
+      PY.runManagedFinal $ do
         void $ MTR.allocate (return ()) $ const (IO.putMVar mva ())
         PY.managedLocal $ do
           liftIO $ IO.tryReadMVar mva >>= \result -> run mAssertions $ result === Nothing


### PR DESCRIPTION
`runManaged` only requires `Embed IO`, but a cost of this is that it
requires forking a new thread when run. If the final monad is `IO`, we
can avoid needing this. `runManagedFinal` implements a version of
`runManaged` that doesn't need to fork.